### PR TITLE
introduce optional junit mutflowtest annotation flag skipCauseNotAllCasesCovered

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -381,7 +381,20 @@ class PaymentServiceTest { ... }
 
 **Why class-level filtering?** Point IDs encode the fully qualified class name (e.g., `com.example.Calculator_0`), so class-based matching is natural. The annotation uses `KClass<*>` references, which are type-safe and refactoring-friendly.
 
-### 8. Partial Run Detection
+### 8. Skipping Mutation Testing
+
+When writing tests incrementally, you may not have all test cases ready yet. Running mutation testing in this state produces noise — surviving mutants for code you simply haven't tested yet. The `skipCauseNotAllCasesCovered` flag lets you skip mutation runs entirely while keeping the `@MutFlowTest` annotation in place:
+
+```kotlin
+@MutFlowTest(skipCauseNotAllCasesCovered = true)
+class CalculatorTest { ... }
+```
+
+**How it works:** When the flag is `true`, the extension only provides the baseline invocation context (run 0). All tests execute normally, but no mutation runs are generated. The session is still created and closed cleanly.
+
+**Why a boolean flag instead of removing `@MutFlowTest`?** Removing the annotation loses the signal that mutation testing is intended for this class. The flag serves as a visible reminder — the developer sees `skipCauseNotAllCasesCovered = true` and knows they need to come back and finish coverage. The deliberately verbose name reinforces that this is a temporary state, not a permanent opt-out.
+
+### 9. Partial Run Detection
 
 When running a single test method from an IDE (e.g., IntelliJ's "Run Test" on one method), mutation testing is automatically skipped. This prevents false positives — mutations that would be killed by *other* tests in the class would incorrectly appear as survivors.
 
@@ -401,7 +414,7 @@ The baseline still runs normally (tests execute, mutations are discovered), but 
 
 **Rationale:** Mutation testing evaluates the *entire test suite's* ability to catch mutations. Running it with a subset produces meaningless results — better to skip and provide a clear message.
 
-### 9. Timeout Detection for Infinite Loops
+### 10. Timeout Detection for Infinite Loops
 
 Certain mutations can cause infinite loops — most commonly when flipping a relational operator in a loop condition (e.g., `<` → `>` in `while (i < n)`). Without protection, these mutations would hang the test run indefinitely.
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,22 @@ Traps run in the order provided, regardless of selection strategy. After all tra
 [mutflow]     (Calculator.kt:8) > → >=
 ```
 
+### Skipping Mutation Testing
+
+When you're still writing test cases and don't have full coverage yet, you can skip mutation testing entirely while keeping the test structure in place:
+
+```kotlin
+@MutFlowTest(skipCauseNotAllCasesCovered = true)
+class CalculatorTest { ... }
+```
+
+With this flag, only the baseline run executes — your tests run normally without any mutation runs. Once you've written all your test cases, remove the flag (or set it to `false`) and mutflow will start testing mutations again.
+
+This is useful when you want to:
+- Work on test coverage incrementally without mutation failures blocking you
+- Keep your `@MutFlowTest` annotation in place as a reminder that mutation testing is intended
+- Separate "make tests pass" from "kill all mutants" as distinct workflow phases
+
 ### Suppressing Mutations
 
 mutflow provides three levels of suppression granularity:

--- a/mutflow-junit6/src/main/kotlin/io/github/anschnapp/mutflow/junit/MutFlowExtension.kt
+++ b/mutflow-junit6/src/main/kotlin/io/github/anschnapp/mutflow/junit/MutFlowExtension.kt
@@ -45,6 +45,7 @@ class MutFlowExtension : ClassTemplateInvocationContextProvider {
             .orElseThrow { IllegalStateException("@MutFlowTest annotation not found") }
 
         val maxRuns = annotation.maxRuns
+        val skipMutations = annotation.skipCauseNotAllCasesCovered
 
         // Count test methods for partial run detection
         val testClass = context.requiredTestClass
@@ -67,6 +68,7 @@ class MutFlowExtension : ClassTemplateInvocationContextProvider {
         return generateSequence(0 to null as Mutation?) { (run, _) ->
             val nextRun = run + 1
             when {
+                skipMutations -> null // Skip mutation runs, only baseline
                 nextRun >= maxRuns -> null // Stop at maxRuns
                 nextRun == 1 -> {
                     // After baseline, select first mutation

--- a/mutflow-junit6/src/main/kotlin/io/github/anschnapp/mutflow/junit/MutFlowTest.kt
+++ b/mutflow-junit6/src/main/kotlin/io/github/anschnapp/mutflow/junit/MutFlowTest.kt
@@ -48,6 +48,9 @@ import kotlin.reflect.KClass
  * @param timeoutMs Maximum time in milliseconds for each mutation run before it is considered
  *                  timed out (likely an infinite loop). Default is 60000 (60 seconds).
  *                  Set to 0 to disable timeout detection.
+ * @param skipCauseNotAllCasesCovered When true, skips mutation testing and only runs the
+ *                  baseline (regular tests). Use this while you are still writing test cases
+ *                  and are not yet ready for mutation testing. Default is false.
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
@@ -58,5 +61,6 @@ annotation class MutFlowTest(
     val traps: Array<String> = [],
     val includeTargets: Array<KClass<*>> = [],
     val excludeTargets: Array<KClass<*>> = [],
-    val timeoutMs: Long = 60_000
+    val timeoutMs: Long = 60_000,
+    val skipCauseNotAllCasesCovered: Boolean = false
 )


### PR DESCRIPTION
Introduce optional @MutFlowTest flag skipCauseNotAllCasesCovered to skip mutation runs while test cases are still being written
