### PR TITLE
Session-Tracking: improve session identification with typed SessionId

### DIFF
--- a/mutflow-junit6/src/main/kotlin/io/github/anschnapp/mutflow/junit/MutFlowExtension.kt
+++ b/mutflow-junit6/src/main/kotlin/io/github/anschnapp/mutflow/junit/MutFlowExtension.kt
@@ -5,6 +5,7 @@ import io.github.anschnapp.mutflow.MutantSurvivedException
 import io.github.anschnapp.mutflow.MutationTimedOutException
 import io.github.anschnapp.mutflow.Mutation
 import io.github.anschnapp.mutflow.Selection
+import io.github.anschnapp.mutflow.SessionId
 import io.github.anschnapp.mutflow.Shuffle
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback
@@ -86,7 +87,7 @@ class MutFlowExtension : ClassTemplateInvocationContextProvider {
     }
 
     private fun createInvocationContext(
-        sessionId: String,
+        sessionId: SessionId,
         run: Int,
         mutation: Mutation?
     ): ClassTemplateInvocationContext {

--- a/mutflow-runtime/src/main/kotlin/io/github/anschnapp/mutflow/MutFlow.kt
+++ b/mutflow-runtime/src/main/kotlin/io/github/anschnapp/mutflow/MutFlow.kt
@@ -30,12 +30,12 @@ import kotlin.random.Random
 object MutFlow {
 
     // Active sessions, keyed by session ID
-    private val sessions = mutableMapOf<String, MutFlowSession>()
+    private val sessions = mutableMapOf<SessionId, MutFlowSession>()
 
     // Maps thread ID to session ID, set in startRun, cleared in endRun.
     // Allows parameterless underTest() to find the right session when
     // multiple test classes run in parallel on different threads.
-    private val threadToSession = ConcurrentHashMap<Long, String>()
+    private val threadToSession = ConcurrentHashMap<Long, SessionId>()
 
     // ==================== Session Management (for JUnit extension) ====================
 
@@ -59,8 +59,8 @@ object MutFlow {
         includeTargets: List<String> = emptyList(),
         excludeTargets: List<String> = emptyList(),
         timeoutMs: Long = 60_000
-    ): String {
-        val id = UUID.randomUUID().toString()
+    ): SessionId {
+        val id = SessionId(UUID.randomUUID())
         val session = MutFlowSession(
             id = id,
             selection = selection,
@@ -80,7 +80,7 @@ object MutFlow {
      * Closes a session and cleans up its state.
      * Called by JUnit extension when a @MutFlowTest class finishes.
      */
-    fun closeSession(sessionId: String) {
+    fun closeSession(sessionId: SessionId) {
         val session = sessions.remove(sessionId)
         session?.printSummary()
     }
@@ -93,7 +93,7 @@ object MutFlow {
      * @param run Run number (must be >= 1)
      * @return The selected mutation, or null if exhausted
      */
-    fun selectMutationForRun(sessionId: String, run: Int): Mutation? {
+    fun selectMutationForRun(sessionId: SessionId, run: Int): Mutation? {
         val session = sessions[sessionId]
             ?: error("Session not found: $sessionId")
         return session.selectMutationForRun(run)
@@ -107,7 +107,7 @@ object MutFlow {
      * @param run Run number: 0 = baseline, 1+ = mutation runs
      * @param mutation Pre-selected mutation for this run (null for baseline)
      */
-    fun startRun(sessionId: String, run: Int, mutation: Mutation? = null) {
+    fun startRun(sessionId: SessionId, run: Int, mutation: Mutation? = null) {
         val session = sessions[sessionId]
             ?: error("Session not found: $sessionId")
         threadToSession[Thread.currentThread().id] = sessionId
@@ -118,7 +118,7 @@ object MutFlow {
      * Ends the current run within a session.
      * Called by JUnit extension after each class template invocation.
      */
-    fun endRun(sessionId: String) {
+    fun endRun(sessionId: SessionId) {
         sessions[sessionId]?.endRun()
         threadToSession.remove(Thread.currentThread().id)
     }
@@ -126,12 +126,12 @@ object MutFlow {
     /**
      * Returns the session for the given ID.
      */
-    fun getSession(sessionId: String): MutFlowSession? = sessions[sessionId]
+    fun getSession(sessionId: SessionId): MutFlowSession? = sessions[sessionId]
 
     /**
      * Returns true if the session has untested mutations remaining.
      */
-    fun hasUntestedMutations(sessionId: String): Boolean {
+    fun hasUntestedMutations(sessionId: SessionId): Boolean {
         return sessions[sessionId]?.hasUntestedMutations() ?: false
     }
 

--- a/mutflow-runtime/src/main/kotlin/io/github/anschnapp/mutflow/MutFlowSession.kt
+++ b/mutflow-runtime/src/main/kotlin/io/github/anschnapp/mutflow/MutFlowSession.kt
@@ -1,6 +1,12 @@
 package io.github.anschnapp.mutflow
 
+import java.util.UUID
 import kotlin.random.Random
+
+/**
+ * Identifier for [MutFlowSession] instances.
+ */
+data class SessionId(val value: UUID)
 
 /**
  * Holds all mutation testing state for a single test class execution.
@@ -9,7 +15,7 @@ import kotlin.random.Random
  * closed when the class finishes.
  */
 class MutFlowSession internal constructor(
-    val id: String,
+    val id: SessionId,
     val selection: Selection,
     val shuffle: Shuffle,
     val maxRuns: Int,

--- a/mutflow-runtime/src/test/kotlin/io/github/anschnapp/mutflow/MutFlowTest.kt
+++ b/mutflow-runtime/src/test/kotlin/io/github/anschnapp/mutflow/MutFlowTest.kt
@@ -258,13 +258,13 @@ class MutFlowTest {
 
     // ==================== Target filter tests (session-based) ====================
 
-    private fun runBaselineWithSession(sessionId: String, block: () -> Unit) {
+    private fun runBaselineWithSession(sessionId: SessionId, block: () -> Unit) {
         MutFlow.startRun(sessionId, 0)
         MutFlow.underTest(block)
         MutFlow.endRun(sessionId)
     }
 
-    private fun runMutationWithSession(sessionId: String, run: Int): Mutation? {
+    private fun runMutationWithSession(sessionId: SessionId, run: Int): Mutation? {
         val mutation = MutFlow.selectMutationForRun(sessionId, run) ?: return null
         MutFlow.startRun(sessionId, run, mutation)
         MutFlow.underTest { /* execute with mutation active */ }


### PR DESCRIPTION
This should make the code safer and clearer at the same time, removing the 'primitive obsession' design smell from such a central identifier.