### PR TITLE
introduce verification mode strict lenient and disabled, with the option to overwrite it via env

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -478,6 +478,55 @@ class CalculatorTest { ... }
 **Design rationale - fail loudly, not silently:**
 When a timeout occurs, the test **fails** rather than silently marking the mutation as killed. This ensures the developer notices and takes action (adds `// mutflow:ignore` on the affected line). Silent handling would mask slow mutation runs that accumulate over time.
 
+### 10. Verification Mode
+
+Controls how surviving mutations are handled. Three modes are available:
+
+```kotlin
+enum class VerificationMode {
+    STRICT,    // survivors cause test failure (default)
+    LENIENT,   // survivors are reported but don't fail
+    DISABLED   // mutation runs are skipped entirely
+}
+```
+
+**Per-annotation configuration:**
+```kotlin
+@MutFlowTest(verificationMode = VerificationMode.LENIENT)
+class CalculatorTest { ... }
+```
+
+**Environment variable override:**
+
+The `MUTFLOW_VERIFICATION_MODE` environment variable takes precedence over the annotation value. This enables phased CI pipelines without changing code:
+
+```bash
+MUTFLOW_VERIFICATION_MODE=DISABLED ./gradlew test   # fast: regular tests only
+MUTFLOW_VERIFICATION_MODE=LENIENT ./gradlew test     # report mutations, don't fail
+./gradlew test                                        # full strict mutation testing
+```
+
+**Resolution order:**
+1. Check `MUTFLOW_VERIFICATION_MODE` environment variable
+2. If set and valid (`STRICT`, `LENIENT`, `DISABLED`, case-insensitive): use it
+3. If set but invalid: print warning, fall back to annotation value
+4. If not set: use annotation value (default: `STRICT`)
+
+**How each mode affects the test lifecycle:**
+
+| Phase | STRICT | LENIENT | DISABLED |
+|-------|--------|---------|----------|
+| Baseline (Run 0) | Runs normally | Runs normally | Runs normally |
+| Mutation runs | All mutations tested | All mutations tested | Skipped entirely |
+| Surviving mutation | `MutantSurvivedException` thrown — test fails | Printed as warning, test passes | N/A |
+| Summary | Full report | Full report | No mutation data |
+
+**Design rationale:**
+
+The default is `STRICT` because mutflow's value proposition is catching test gaps — silently ignoring survivors would undermine that. However, real-world adoption is incremental: teams adding mutflow to an existing codebase need a way to see mutation results without blocking their build. `LENIENT` serves this purpose. `DISABLED` provides a zero-overhead escape hatch for performance-sensitive workflows (equivalent to `mutflow.enabled=false` at the Gradle level but controllable per-run without rebuilding).
+
+The environment variable override is intentional: it allows the same test code to behave differently in different pipeline stages. A team can run `DISABLED` in their fast-feedback loop, `LENIENT` in nightly builds, and `STRICT` in release pipelines — all without touching the test annotations.
+
 ## Architecture
 
 ### Module Responsibilities
@@ -839,12 +888,14 @@ Code only reached outside `MutFlow.underTest { }` blocks produces no mutations. 
 - Touch count tracking during baseline
 - Target filtering: `includeTargets`/`excludeTargets` for scoping mutations by class
 - `MutationsExhaustedException` when all mutations tested
+- `VerificationMode` enum: `STRICT`, `LENIENT`, `DISABLED`
 
 **mutflow-junit6:**
 - `@MutFlowTest` meta-annotation combining `@ClassTemplate` + `@ExtendWith`
 - `MutFlowExtension` implementing `ClassTemplateInvocationContextProvider`
 - Session lifecycle management (create, startRun, endRun, close)
 - Mutation selection at context creation for accurate display names
+- Verification mode resolution: annotation parameter with `MUTFLOW_VERIFICATION_MODE` env var override
 
 **mutflow-test-sample:**
 - Integration tests demonstrating both APIs

--- a/README.md
+++ b/README.md
@@ -269,6 +269,42 @@ Traps run in the order provided, regardless of selection strategy. After all tra
 [mutflow]     (Calculator.kt:8) > → >=
 ```
 
+### Verification Mode
+
+By default, mutflow uses **strict** verification: surviving mutations fail the build. You can change this behavior per test class or globally.
+
+```kotlin
+@MutFlowTest(verificationMode = VerificationMode.STRICT)   // default — survivors fail the build
+@MutFlowTest(verificationMode = VerificationMode.LENIENT)  // survivors are reported but don't fail
+@MutFlowTest(verificationMode = VerificationMode.DISABLED) // mutation runs are skipped entirely
+```
+
+**When to use each mode:**
+- `STRICT` — Default. Use for CI pipelines where mutation coverage must be maintained.
+- `LENIENT` — Use when building up test coverage incrementally. Mutations still run and are reported in the summary, but survivors don't break the build. This lets you focus on writing regular tests first and address surviving mutations later.
+- `DISABLED` — Use when you only want fast feedback from regular tests. Only the baseline runs — no mutations are tested at all.
+
+**Environment variable override:**
+
+The `MUTFLOW_VERIFICATION_MODE` environment variable overrides the annotation value for all test classes. This enables phased CI pipelines:
+
+```bash
+# Phase 1: Fast feedback — only regular tests
+MUTFLOW_VERIFICATION_MODE=DISABLED ./gradlew test
+
+# Phase 2: Full mutation testing
+./gradlew test
+```
+
+Or for a gradual adoption workflow:
+
+```bash
+# Run mutation tests but don't block the build yet
+MUTFLOW_VERIFICATION_MODE=LENIENT ./gradlew test
+```
+
+The environment variable accepts `STRICT`, `LENIENT`, or `DISABLED` (case-insensitive). Invalid values produce a warning and fall back to the annotation value.
+
 ### Suppressing Mutations
 
 Suppression works regardless of how the class was targeted (annotation or Gradle config). mutflow provides three levels of suppression granularity:
@@ -357,6 +393,7 @@ Selection strategies (`PureRandom`, `MostLikelyRandom`, `MostLikelyStable`) and 
 - **Mutation result tracking** - Killed mutations show as PASSED (exception swallowed), survivors fail the build
 
 **Control**
+- **Verification mode** - `STRICT` (default, survivors fail), `LENIENT` (survivors reported only), `DISABLED` (skip mutations). Configurable per annotation or globally via `MUTFLOW_VERIFICATION_MODE` env var
 - **`@SuppressMutations`** - Skip mutations on specific classes or functions
 - **Comment-based line suppression** - `// mutflow:ignore` and `// mutflow:falsePositive` to skip individual lines (zero production overhead)
 - **Target filtering** - `includeTargets`/`excludeTargets` to scope mutations by class in integration tests

--- a/mutflow-junit6/src/main/kotlin/io/github/anschnapp/mutflow/junit/MutFlowExtension.kt
+++ b/mutflow-junit6/src/main/kotlin/io/github/anschnapp/mutflow/junit/MutFlowExtension.kt
@@ -7,6 +7,7 @@ import io.github.anschnapp.mutflow.Mutation
 import io.github.anschnapp.mutflow.Selection
 import io.github.anschnapp.mutflow.SessionId
 import io.github.anschnapp.mutflow.Shuffle
+import io.github.anschnapp.mutflow.VerificationMode
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback
 import org.junit.jupiter.api.extension.BeforeClassTemplateInvocationCallback
@@ -47,6 +48,9 @@ class MutFlowExtension : ClassTemplateInvocationContextProvider {
 
         val maxRuns = annotation.maxRuns
 
+        // Resolve effective verification mode: env var overrides annotation
+        val effectiveMode = resolveVerificationMode(annotation.verificationMode)
+
         // Count test methods for partial run detection
         val testClass = context.requiredTestClass
         val expectedTestCount = countTestMethods(testClass)
@@ -60,8 +64,22 @@ class MutFlowExtension : ClassTemplateInvocationContextProvider {
             traps = annotation.traps.toList(),
             includeTargets = annotation.includeTargets.map { it.qualifiedName!! },
             excludeTargets = annotation.excludeTargets.map { it.qualifiedName!! },
-            timeoutMs = annotation.timeoutMs
+            timeoutMs = annotation.timeoutMs,
+            verificationMode = effectiveMode
         )
+
+        // DISABLED mode: only run baseline, skip all mutation runs
+        if (effectiveMode == VerificationMode.DISABLED) {
+            println("[mutflow] Verification mode: DISABLED - skipping mutation runs")
+            return generateSequence(0 to null as Mutation?) { null }
+                .map { (run, mutation) -> createInvocationContext(sessionId, run, mutation) }
+                .asStream()
+                .onClose { MutFlow.closeSession(sessionId) }
+        }
+
+        if (effectiveMode == VerificationMode.LENIENT) {
+            println("[mutflow] Verification mode: LENIENT - surviving mutations will not cause test failure")
+        }
 
         // Generate invocation contexts lazily
         // Each context is created AFTER the previous run completes
@@ -154,8 +172,12 @@ class MutFlowExtension : ClassTemplateInvocationContextProvider {
                             if (session.didMutationSurvive()) {
                                 val survivedMutation = session.getActiveMutation()!!
                                 val displayName = session.getDisplayName(survivedMutation)
-                                MutFlow.endRun(sessionId)
-                                throw MutantSurvivedException(survivedMutation, displayName)
+                                if (session.getVerificationMode() == VerificationMode.STRICT) {
+                                    MutFlow.endRun(sessionId)
+                                    throw MutantSurvivedException(survivedMutation, displayName)
+                                } else {
+                                    println("[mutflow] Mutation survived (lenient): $displayName")
+                                }
                             }
                         }
                         MutFlow.endRun(sessionId)
@@ -179,6 +201,20 @@ class MutFlowExtension : ClassTemplateInvocationContextProvider {
     private fun countTestMethods(testClass: Class<*>): Int {
         return testClass.methods.count { method ->
             method.isAnnotationPresent(Test::class.java)
+        }
+    }
+
+    /**
+     * Resolves the effective verification mode.
+     * The MUTFLOW_VERIFICATION_MODE environment variable takes precedence over the annotation value.
+     */
+    private fun resolveVerificationMode(annotationMode: VerificationMode): VerificationMode {
+        val envValue = System.getenv("MUTFLOW_VERIFICATION_MODE") ?: return annotationMode
+        return try {
+            VerificationMode.valueOf(envValue.uppercase())
+        } catch (e: IllegalArgumentException) {
+            println("[mutflow] WARNING: Invalid MUTFLOW_VERIFICATION_MODE value: '$envValue'. Valid values: ${VerificationMode.entries.joinToString()}. Falling back to annotation value: $annotationMode")
+            annotationMode
         }
     }
 }

--- a/mutflow-junit6/src/main/kotlin/io/github/anschnapp/mutflow/junit/MutFlowTest.kt
+++ b/mutflow-junit6/src/main/kotlin/io/github/anschnapp/mutflow/junit/MutFlowTest.kt
@@ -1,5 +1,6 @@
 package io.github.anschnapp.mutflow.junit
 
+import io.github.anschnapp.mutflow.VerificationMode
 import org.junit.jupiter.api.ClassTemplate
 import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.reflect.KClass
@@ -48,6 +49,11 @@ import kotlin.reflect.KClass
  * @param timeoutMs Maximum time in milliseconds for each mutation run before it is considered
  *                  timed out (likely an infinite loop). Default is 60000 (60 seconds).
  *                  Set to 0 to disable timeout detection.
+ * @param verificationMode Controls how surviving mutations are handled.
+ *                         STRICT (default): survivors cause test failure.
+ *                         LENIENT: survivors are reported but don't fail.
+ *                         DISABLED: mutation runs are skipped entirely.
+ *                         Can be overridden globally via the MUTFLOW_VERIFICATION_MODE environment variable.
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
@@ -58,5 +64,6 @@ annotation class MutFlowTest(
     val traps: Array<String> = [],
     val includeTargets: Array<KClass<*>> = [],
     val excludeTargets: Array<KClass<*>> = [],
-    val timeoutMs: Long = 60_000
+    val timeoutMs: Long = 60_000,
+    val verificationMode: VerificationMode = VerificationMode.STRICT
 )

--- a/mutflow-runtime/src/main/kotlin/io/github/anschnapp/mutflow/MutFlow.kt
+++ b/mutflow-runtime/src/main/kotlin/io/github/anschnapp/mutflow/MutFlow.kt
@@ -58,7 +58,8 @@ object MutFlow {
         traps: List<String> = emptyList(),
         includeTargets: List<String> = emptyList(),
         excludeTargets: List<String> = emptyList(),
-        timeoutMs: Long = 60_000
+        timeoutMs: Long = 60_000,
+        verificationMode: VerificationMode = VerificationMode.STRICT
     ): SessionId {
         val id = SessionId(UUID.randomUUID())
         val session = MutFlowSession(
@@ -70,7 +71,8 @@ object MutFlow {
             traps = traps,
             includeTargets = includeTargets,
             excludeTargets = excludeTargets,
-            timeoutMs = timeoutMs
+            timeoutMs = timeoutMs,
+            verificationMode = verificationMode
         )
         sessions[id] = session
         return id
@@ -389,6 +391,33 @@ enum class Selection {
      * Tie-breaker: alphabetical by pointId, then by variantIndex.
      */
     MostLikelyStable
+}
+
+/**
+ * Controls how mutation testing results are verified.
+ *
+ * Can be set per test class via @MutFlowTest(verificationMode = ...) or
+ * globally via the MUTFLOW_VERIFICATION_MODE environment variable.
+ * The environment variable takes precedence over the annotation value.
+ */
+enum class VerificationMode {
+    /**
+     * Surviving mutations cause test failure.
+     * This is the default mode — ensures all mutations are killed.
+     */
+    STRICT,
+
+    /**
+     * Surviving mutations are reported in the summary but do not cause test failure.
+     * Useful when building up test coverage incrementally.
+     */
+    LENIENT,
+
+    /**
+     * Mutation runs are skipped entirely — only the baseline (regular tests) runs.
+     * Useful for fast feedback when mutation testing is not needed.
+     */
+    DISABLED
 }
 
 /**

--- a/mutflow-runtime/src/main/kotlin/io/github/anschnapp/mutflow/MutFlowSession.kt
+++ b/mutflow-runtime/src/main/kotlin/io/github/anschnapp/mutflow/MutFlowSession.kt
@@ -23,7 +23,8 @@ class MutFlowSession internal constructor(
     private val traps: List<String> = emptyList(),
     private val includeTargets: List<String> = emptyList(),
     private val excludeTargets: List<String> = emptyList(),
-    private val timeoutMs: Long = 60_000
+    private val timeoutMs: Long = 60_000,
+    private val verificationMode: VerificationMode = VerificationMode.STRICT
 ) {
     // Discovered points with their variant counts (built during baseline)
     private val discoveredPoints = mutableMapOf<String, Int>() // pointId -> variantCount
@@ -253,6 +254,11 @@ class MutFlowSession internal constructor(
      * Returns the currently active mutation, if any.
      */
     fun getActiveMutation(): Mutation? = activeMutation
+
+    /**
+     * Returns the verification mode for this session.
+     */
+    fun getVerificationMode(): VerificationMode = verificationMode
 
     /**
      * Ends the current run.

--- a/mutflow-test-sample/src/test/kotlin/sample/VerificationModeDisabledTest.kt
+++ b/mutflow-test-sample/src/test/kotlin/sample/VerificationModeDisabledTest.kt
@@ -1,0 +1,27 @@
+package sample
+
+import io.github.anschnapp.mutflow.MutFlow
+import io.github.anschnapp.mutflow.VerificationMode
+import io.github.anschnapp.mutflow.junit.MutFlowTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+/**
+ * Tests that DISABLED verification mode skips mutation runs entirely.
+ *
+ * Only the baseline run should execute. This test has weak coverage that would
+ * produce surviving mutations, but since mutation runs are skipped, it passes.
+ */
+@MutFlowTest(verificationMode = VerificationMode.DISABLED)
+class VerificationModeDisabledTest {
+
+    private val calculator = Calculator()
+
+    @Test
+    fun `isPositive returns true for positive numbers`() {
+        val result = MutFlow.underTest {
+            calculator.isPositive(5)
+        }
+        assertTrue(result, "isPositive(5) should be true")
+    }
+}

--- a/mutflow-test-sample/src/test/kotlin/sample/VerificationModeLenientTest.kt
+++ b/mutflow-test-sample/src/test/kotlin/sample/VerificationModeLenientTest.kt
@@ -1,0 +1,28 @@
+package sample
+
+import io.github.anschnapp.mutflow.MutFlow
+import io.github.anschnapp.mutflow.VerificationMode
+import io.github.anschnapp.mutflow.junit.MutFlowTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+/**
+ * Tests that LENIENT verification mode allows surviving mutations without failing.
+ *
+ * This test intentionally has weak coverage: it only tests isPositive(5) = true,
+ * which means mutations like > → >= will survive. In STRICT mode this would fail,
+ * but in LENIENT mode the test should pass with survivors only reported.
+ */
+@MutFlowTest(verificationMode = VerificationMode.LENIENT)
+class VerificationModeLenientTest {
+
+    private val calculator = Calculator()
+
+    @Test
+    fun `isPositive returns true for positive numbers`() {
+        val result = MutFlow.underTest {
+            calculator.isPositive(5)
+        }
+        assertTrue(result, "isPositive(5) should be true")
+    }
+}


### PR DESCRIPTION
 VerificationMode added STRICT (default), LENIENT, DISABLED
 
 ```kotlin
 enum class VerificationMode {
    /**
     * Surviving mutations cause test failure.
     * This is the default mode — ensures all mutations are killed.
     */
    STRICT,

    /**
     * Surviving mutations are reported in the summary but do not cause test failure.
     * Useful when building up test coverage incrementally.
     */
    LENIENT,

    /**
     * Mutation runs are skipped entirely — only the baseline (regular tests) runs.
     * Useful for fast feedback when mutation testing is not needed.
     */
    DISABLED
}

```
 
 could be configured via MutflowTest annotation

could be overwritten via Environment variable MUTFLOW_VERIFICATION_MODE