### PR TITLE
add option to define mutation targets via gradle plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 .kotlin
 .idea
 CLAUDE.md
+example

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -282,20 +282,41 @@ Traps are a **temporary debugging aid**:
 - Easy to update if code moves (the warning shows available mutations)
 - Unambiguous even when the same operator appears multiple times on one line
 
-### 6. Scoped Mutations via Annotations
+### 6. Scoped Mutations via Annotations and Gradle Config
 
-The compiler plugin only injects mutations into annotated classes:
+The compiler plugin injects mutations into classes that are either annotated with `@MutationTarget` or matched by target patterns configured in the Gradle plugin:
 
 ```kotlin
+// Option 1: Annotation on production code
 @MutationTarget
 class Calculator {
     // mutations injected here
 }
 
-class Logger {
-    // no mutations - not under test
+// Option 2: Gradle config (no annotation needed on production code)
+// build.gradle.kts
+mutflow {
+    targets = listOf(
+        "com.example.Calculator",       // exact class
+        "com.example.service.*",        // all classes in a package
+        "com.example.service.**",       // package + all subpackages
+        "com.example.*Service"          // glob pattern
+    )
 }
 ```
+
+Both mechanisms can be combined freely — a class is mutated if it matches either `@MutationTarget` or a Gradle target pattern. If both match the same class, it is simply mutated once (no duplication).
+
+**Why two mechanisms?**
+- `@MutationTarget` is convenient for small projects and makes mutation scope visible in the code
+- Gradle config addresses a common concern: annotating production code with test-related annotations from an external library feels invasive (see [GitHub issue #2](https://github.com/anschnapp/mutflow/issues/2)). The Gradle config keeps all mutation testing configuration in the test/build layer
+
+**Pattern matching:** Target patterns support glob-style matching:
+- `.` matches literal dots in package/class names
+- `*` matches a single name segment (does not cross dots)
+- `**` matches any number of segments (crosses dots)
+
+Patterns are compiled to regexes once at plugin initialization and matched against each class's fully qualified name during IR transformation.
 
 This limits bytecode bloat and keeps mutations relevant.
 
@@ -480,6 +501,7 @@ When a timeout occurs, the test **fails** rather than silently marking the mutat
 │                           │  Depends on: mutflow-core           │
 ├─────────────────────────────────────────────────────────────────┤
 │  mutflow-compiler-plugin  │  Transforms @MutationTarget classes │
+│                           │  and Gradle-configured target classes│
 │                           │  Injects MutationRegistry.check()   │
 │                           │  Four operator interfaces:          │
 │                           │    MutationOperator (IrCall nodes)  │
@@ -743,6 +765,8 @@ Code only reached outside `MutFlow.underTest { }` blocks produces no mutations. 
 
 **mutflow-compiler-plugin:**
 - K2 compiler plugin with extensible mutation operator mechanism
+- `MutflowCommandLineProcessor` receives target patterns from Gradle plugin via `SubpluginOption`
+- Target pattern matching: glob-style patterns (`*`, `**`) compiled to regex for FQN matching
 - Four operator interfaces for different IR node types:
   - `MutationOperator` — for `IrCall` nodes (comparison operators, etc.)
   - `ReturnMutationOperator` — for `IrReturn` nodes (return statement mutations)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,30 @@ Once available, the plugin automatically:
 
 **Important:** The plugin uses a dual-compilation approach — your production JAR remains clean (no mutation code), while tests run against mutated code.
 
+### Specifying Mutation Targets
+
+There are two ways to tell mutflow which classes to mutate — use either or both:
+
+**Option 1: `@MutationTarget` annotation** (on production code)
+```kotlin
+@MutationTarget
+class Calculator { ... }
+```
+
+**Option 2: Gradle configuration** (no annotations on production code)
+```kotlin
+mutflow {
+    targets = listOf(
+        "com.example.Calculator",       // exact class
+        "com.example.service.*",        // all classes in a package
+        "com.example.service.**",       // package + all subpackages
+        "com.example.*Service"          // glob pattern
+    )
+}
+```
+
+Both can be combined freely. If a class matches either mechanism, it will be mutated. The Gradle config is useful when you prefer not to annotate production code with test-related annotations.
+
 ### Disabling Mutation Testing
 
 You can completely disable mutation testing without removing the plugin. When disabled, no compiler plugin is registered and no extra compilation happens — zero overhead.
@@ -92,11 +116,14 @@ When disabled, your code still compiles normally (`@MutationTarget` and `@MutFlo
 ## Quick Start
 
 ```kotlin
-// Mark code under test
+// Mark code under test (Option 1: annotation)
 @MutationTarget
 class Calculator {
     fun isPositive(x: Int) = x > 0
 }
+
+// Or use Gradle config instead (Option 2: no annotation needed)
+// mutflow { targets = listOf("com.example.Calculator") }
 
 // Test with mutation testing - simple!
 @MutFlowTest
@@ -244,7 +271,7 @@ Traps run in the order provided, regardless of selection strategy. After all tra
 
 ### Suppressing Mutations
 
-mutflow provides three levels of suppression granularity:
+Suppression works regardless of how the class was targeted (annotation or Gradle config). mutflow provides three levels of suppression granularity:
 
 **Class level** — skip all mutations in a class:
 ```kotlin
@@ -319,7 +346,7 @@ Selection strategies (`PureRandom`, `MostLikelyRandom`, `MostLikelyStable`) and 
 
 **Core**
 - **JUnit 6 integration** — `@MutFlowTest` annotation for automatic multi-run orchestration
-- **K2 compiler plugin** — Transforms `@MutationTarget` classes with multiple mutation types
+- **K2 compiler plugin** — Transforms `@MutationTarget` classes (or Gradle-configured target patterns) with multiple mutation types
 - **Parameterless API** — Simple `MutFlow.underTest { }` when using JUnit extension
 - **Runs all mutations by default** — Zero-config: `@MutFlowTest` tests every discovered mutation
 

--- a/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutflowCommandLineProcessor.kt
+++ b/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutflowCommandLineProcessor.kt
@@ -1,0 +1,39 @@
+package io.github.anschnapp.mutflow.compiler
+
+import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
+import org.jetbrains.kotlin.compiler.plugin.CliOption
+import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.CompilerConfigurationKey
+
+val MUTFLOW_TARGET_PATTERNS_KEY = CompilerConfigurationKey<List<String>>("mutflow target patterns")
+
+@OptIn(ExperimentalCompilerApi::class)
+class MutflowCommandLineProcessor : CommandLineProcessor {
+
+    override val pluginId: String = "io.github.anschnapp.mutflow"
+
+    override val pluginOptions: Collection<AbstractCliOption> = listOf(
+        CliOption(
+            optionName = "target",
+            valueDescription = "<class-or-package-pattern>",
+            description = "Target class or package pattern for mutation (e.g., com.example.Calculator, com.example.service.*)",
+            required = false,
+            allowMultipleOccurrences = true
+        )
+    )
+
+    override fun processOption(
+        option: AbstractCliOption,
+        value: String,
+        configuration: CompilerConfiguration
+    ) {
+        when (option.optionName) {
+            "target" -> {
+                val existing = configuration.get(MUTFLOW_TARGET_PATTERNS_KEY) ?: emptyList()
+                configuration.put(MUTFLOW_TARGET_PATTERNS_KEY, existing + value)
+            }
+        }
+    }
+}

--- a/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutflowCompilerPluginRegistrar.kt
+++ b/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutflowCompilerPluginRegistrar.kt
@@ -36,7 +36,9 @@ class MutflowCompilerPluginRegistrar : CompilerPluginRegistrar() {
     override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
         debug("registerExtensions() called!")
         debug("  configuration: $configuration")
-        IrGenerationExtension.registerExtension(MutflowIrGenerationExtension())
+        val targetPatterns = configuration.get(MUTFLOW_TARGET_PATTERNS_KEY) ?: emptyList()
+        debug("  target patterns: $targetPatterns")
+        IrGenerationExtension.registerExtension(MutflowIrGenerationExtension(targetPatterns))
         debug("  IrGenerationExtension registered")
     }
 }

--- a/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutflowIrGenerationExtension.kt
+++ b/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutflowIrGenerationExtension.kt
@@ -12,7 +12,9 @@ import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
  * 1. Finds classes annotated with @MutationTarget
  * 2. Transforms comparison operators into mutation-aware branches
  */
-class MutflowIrGenerationExtension : IrGenerationExtension {
+class MutflowIrGenerationExtension(
+    private val targetPatterns: List<String> = emptyList()
+) : IrGenerationExtension {
 
     companion object {
         private const val DEBUG = false
@@ -30,7 +32,7 @@ class MutflowIrGenerationExtension : IrGenerationExtension {
         debug("generate() called!")
         debug("  module: ${moduleFragment.name}")
         debug("  files: ${moduleFragment.files.map { it.fileEntry.name }}")
-        val transformer = MutflowIrTransformer(pluginContext)
+        val transformer = MutflowIrTransformer(pluginContext, targetPatterns = targetPatterns)
         moduleFragment.transform(transformer, null)
         debug("  transformation complete")
     }

--- a/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutflowIrTransformer.kt
+++ b/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutflowIrTransformer.kt
@@ -37,7 +37,8 @@ class MutflowIrTransformer(
     private val callOperators: List<MutationOperator> = defaultCallOperators(),
     private val returnOperators: List<ReturnMutationOperator> = defaultReturnOperators(),
     private val functionBodyOperators: List<FunctionBodyMutationOperator> = defaultFunctionBodyOperators(),
-    private val whenOperators: List<WhenMutationOperator> = defaultWhenOperators()
+    private val whenOperators: List<WhenMutationOperator> = defaultWhenOperators(),
+    private val targetPatterns: List<String> = emptyList()
 ) : IrElementTransformerVoid() {
 
     companion object {
@@ -77,6 +78,21 @@ class MutflowIrTransformer(
         fun defaultWhenOperators(): List<WhenMutationOperator> = listOf(
             BooleanLogicOperator()
         )
+
+        /**
+         * Compiles glob-style target patterns into regexes for FQN matching.
+         * - `.` matches literal dots
+         * - `*` matches a single name segment (does not cross dots)
+         * - `**` matches any number of segments (crosses dots)
+         */
+        fun compileTargetPatterns(patterns: List<String>): List<Regex> = patterns.map { pattern ->
+            val regex = pattern
+                .replace(".", "\\.")       // literal dots
+                .replace("**", "\u0000")   // temp placeholder for **
+                .replace("*", "[^.]*")     // * matches single package segment
+                .replace("\u0000", ".*")   // ** matches any depth
+            Regex("^$regex$")
+        }
     }
 
     private val mutationTargetFqName = FqName("io.github.anschnapp.mutflow.MutationTarget")
@@ -118,6 +134,9 @@ class MutflowIrTransformer(
     private var suppressedLines: Set<Int> = emptySet()
     private val suppressedLinesCache = mutableMapOf<String, Set<Int>>()
 
+    // Compiled target patterns from Gradle config (glob-style → regex)
+    private val compiledTargetPatterns: List<Regex> = compileTargetPatterns(targetPatterns)
+
     override fun visitFile(declaration: IrFile): IrFile {
         debug("visitFile: ${declaration.fileEntry.name}")
         val previousFile = currentFile
@@ -137,9 +156,10 @@ class MutflowIrTransformer(
         val previousClass = currentClass
 
         isInMutationTarget = declaration.hasAnnotation(mutationTargetFqName)
+                || matchesTargetPattern(declaration)
         currentClass = declaration
 
-        debug("  hasAnnotation($mutationTargetFqName): $isInMutationTarget")
+        debug("  isInMutationTarget: $isInMutationTarget")
 
         // Check for @SuppressMutations on the class
         if (isInMutationTarget && declaration.hasAnnotation(suppressMutationsFqName)) {
@@ -788,6 +808,17 @@ class MutflowIrTransformer(
         val fileName = file.fileEntry.name.substringAfterLast('/')
         val lineNumber = file.fileEntry.getLineNumber(function.startOffset) + 1
         return "$fileName:$lineNumber"
+    }
+
+    /**
+     * Checks if a class FQN matches any of the configured target patterns from the Gradle config.
+     * Supports glob-style patterns: exact match, single-segment wildcard (*), and
+     * multi-segment wildcard (**).
+     */
+    private fun matchesTargetPattern(declaration: IrClass): Boolean {
+        if (compiledTargetPatterns.isEmpty()) return false
+        val fqName = declaration.fqNameWhenAvailable?.asString() ?: return false
+        return compiledTargetPatterns.any { it.matches(fqName) }
     }
 
     private fun generatePointId(): String {

--- a/mutflow-compiler-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+++ b/mutflow-compiler-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
@@ -1,0 +1,1 @@
+io.github.anschnapp.mutflow.compiler.MutflowCommandLineProcessor

--- a/mutflow-compiler-plugin/src/test/kotlin/io/github/anschnapp/mutflow/compiler/TargetPatternTest.kt
+++ b/mutflow-compiler-plugin/src/test/kotlin/io/github/anschnapp/mutflow/compiler/TargetPatternTest.kt
@@ -1,0 +1,92 @@
+package io.github.anschnapp.mutflow.compiler
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TargetPatternTest {
+
+    private fun matches(pattern: String, fqName: String): Boolean {
+        val compiled = MutflowIrTransformer.compileTargetPatterns(listOf(pattern))
+        return compiled.any { it.matches(fqName) }
+    }
+
+    @Test
+    fun `exact class name matches`() {
+        assertTrue(matches("com.example.Calculator", "com.example.Calculator"))
+    }
+
+    @Test
+    fun `exact class name does not match different class`() {
+        assertFalse(matches("com.example.Calculator", "com.example.Validator"))
+    }
+
+    @Test
+    fun `exact class name does not match subpackage`() {
+        assertFalse(matches("com.example.Calculator", "com.example.sub.Calculator"))
+    }
+
+    @Test
+    fun `single wildcard matches any class in package`() {
+        assertTrue(matches("com.example.*", "com.example.Calculator"))
+        assertTrue(matches("com.example.*", "com.example.Validator"))
+    }
+
+    @Test
+    fun `single wildcard does not cross package boundaries`() {
+        assertFalse(matches("com.example.*", "com.example.sub.Calculator"))
+    }
+
+    @Test
+    fun `single wildcard does not match package itself`() {
+        assertFalse(matches("com.example.*", "com.example"))
+    }
+
+    @Test
+    fun `double wildcard matches any depth`() {
+        assertTrue(matches("com.example.**", "com.example.Calculator"))
+        assertTrue(matches("com.example.**", "com.example.sub.Calculator"))
+        assertTrue(matches("com.example.**", "com.example.sub.deep.Calculator"))
+    }
+
+    @Test
+    fun `double wildcard does not match parent package`() {
+        assertFalse(matches("com.example.**", "com.other.Calculator"))
+    }
+
+    @Test
+    fun `wildcard in class name position`() {
+        assertTrue(matches("com.example.*Service", "com.example.PaymentService"))
+        assertTrue(matches("com.example.*Service", "com.example.AuditService"))
+        assertFalse(matches("com.example.*Service", "com.example.Calculator"))
+    }
+
+    @Test
+    fun `prefix wildcard in class name`() {
+        assertTrue(matches("com.example.Pricing*", "com.example.PricingService"))
+        assertTrue(matches("com.example.Pricing*", "com.example.PricingEngine"))
+        assertFalse(matches("com.example.Pricing*", "com.example.Calculator"))
+    }
+
+    @Test
+    fun `empty pattern list matches nothing`() {
+        val compiled = MutflowIrTransformer.compileTargetPatterns(emptyList())
+        assertFalse(compiled.any { it.matches("com.example.Calculator") })
+    }
+
+    @Test
+    fun `multiple patterns - any match is sufficient`() {
+        val compiled = MutflowIrTransformer.compileTargetPatterns(listOf(
+            "com.example.Calculator",
+            "com.example.service.*"
+        ))
+        assertTrue(compiled.any { it.matches("com.example.Calculator") })
+        assertTrue(compiled.any { it.matches("com.example.service.PaymentService") })
+        assertFalse(compiled.any { it.matches("com.example.Validator") })
+    }
+
+    @Test
+    fun `dots in package names are literal, not regex wildcards`() {
+        assertFalse(matches("com.example.Calculator", "comXexampleXCalculator"))
+    }
+}

--- a/mutflow-gradle-plugin/src/main/kotlin/io/github/anschnapp/mutflow/gradle/MutflowGradlePlugin.kt
+++ b/mutflow-gradle-plugin/src/main/kotlin/io/github/anschnapp/mutflow/gradle/MutflowGradlePlugin.kt
@@ -3,6 +3,7 @@ package io.github.anschnapp.mutflow.gradle
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.file.SourceDirectorySet
@@ -15,6 +16,7 @@ import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 
 abstract class MutflowExtension {
     abstract val enabled: Property<Boolean>
+    abstract val targets: ListProperty<String>
 }
 
 /**
@@ -51,6 +53,7 @@ class MutflowGradlePlugin : Plugin<Project>, KotlinCompilerPluginSupportPlugin {
                 .map { it.toBoolean() }
                 .orElse(true)
         )
+        extension.targets.convention(emptyList())
 
         target.plugins.withId("org.jetbrains.kotlin.jvm") {
             debug("  kotlin.jvm plugin detected, configuring...")
@@ -187,6 +190,14 @@ class MutflowGradlePlugin : Plugin<Project>, KotlinCompilerPluginSupportPlugin {
         kotlinCompilation: KotlinCompilation<*>
     ): Provider<List<SubpluginOption>> {
         debug("applyToCompilation(compilation='${kotlinCompilation.name}')")
-        return kotlinCompilation.target.project.provider { emptyList() }
+        val project = kotlinCompilation.target.project
+        val extension = project.extensions.findByType(MutflowExtension::class.java)
+        return project.provider {
+            val options = mutableListOf<SubpluginOption>()
+            extension?.targets?.get()?.forEach { target ->
+                options.add(SubpluginOption("target", target))
+            }
+            options
+        }
     }
 }


### PR DESCRIPTION
Add mutflow { targets } Gradle DSL to define mutation targets via config, as an alternative to @MutationTarget annotations. Supports exact FQN and glob patterns (*, **).