### PR TITLE
fix: wrong hard coded type on ir when on compiler plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,26 @@ Add the mutflow Gradle plugin to your `build.gradle.kts`:
 
 ```kotlin
 plugins {
-    kotlin("jvm") version "2.3.0"
+    kotlin("jvm") version "2.4.0"
     id("io.github.anschnapp.mutflow") version "<latest-version>"
 }
 ```
+
+### Kotlin Version Compatibility
+
+mutflow tracks the newest Kotlin release and updates frequently. Because compiler
+plugins are tightly coupled to the compiler's internal APIs, each mutflow release
+requires the Kotlin version it was built against - it will not work with older
+Kotlin versions in your project. If you are on an older Kotlin, use the matching
+older mutflow release:
+
+| mutflow | Kotlin |
+|---------|--------|
+| 1.1.0+ | 2.4.x |
+| up to 1.0.3 | 2.2.x - 2.3.x |
+
+A mismatch typically fails with an obscure compiler error (e.g. `NoClassDefFoundError`
+during compilation) - if you see that, check your Kotlin version first.
 
 Once available, the plugin automatically:
 - Adds `mutflow-core` to your implementation dependencies (for `@MutationTarget` annotation)

--- a/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutflowIrTransformer.kt
+++ b/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutflowIrTransformer.kt
@@ -473,11 +473,11 @@ class MutflowIrTransformer(
             call.arguments[6] = builder.irInt(occurrenceOnLine)
         }
 
-        // Generate when expression with inline check() calls - no temporary variable
+        // Generate when expression with inline check() calls - no temporary variable.
         return IrWhenImpl(
             startOffset = original.startOffset,
             endOffset = original.endOffset,
-            type = pluginContext.irBuiltIns.booleanType,
+            type = original.type,
             origin = null
         ).apply {
             variants.forEachIndexed { index, variant ->

--- a/mutflow-test-sample/src/main/kotlin/sample/Calculator.kt
+++ b/mutflow-test-sample/src/main/kotlin/sample/Calculator.kt
@@ -147,4 +147,11 @@ class Calculator {
     fun passThroughBool(flag: Boolean): Boolean {
         return flag
     }
+
+    // --- Double arithmetic (regression: mutation when-wrapper must keep the
+    // expression's type; a Boolean-typed wrapper truncated fractional Doubles) ---
+
+    fun applyRate(amount: Double, rate: Double): Double {
+        return amount * rate
+    }
 }

--- a/mutflow-test-sample/src/test/kotlin/sample/DoubleArithmeticTest.kt
+++ b/mutflow-test-sample/src/test/kotlin/sample/DoubleArithmeticTest.kt
@@ -1,0 +1,42 @@
+package sample
+
+import io.github.anschnapp.mutflow.MutFlow
+import io.github.anschnapp.mutflow.MutationRegistry
+import io.github.anschnapp.mutflow.Selection
+import io.github.anschnapp.mutflow.Shuffle
+import kotlin.test.*
+
+/**
+ * Regression test: mutated Double arithmetic must not lose precision.
+ *
+ * The mutation when-wrapper around IrCall nodes was typed Boolean regardless of
+ * the original expression's type. For Double-valued expressions the JVM backend
+ * then coerced the result, silently truncating fractional values even with no
+ * mutation active (50.0 * 0.05 returned 2.0 instead of 2.5). Every other test
+ * in this module uses integer-valued results, which is why only a fractional
+ * result catches this.
+ */
+class DoubleArithmeticTest {
+
+    private val calculator = Calculator()
+
+    @BeforeTest
+    fun setup() {
+        MutationRegistry.reset()
+        MutFlow.reset()
+    }
+
+    @Test
+    fun `fractional double result survives instrumentation outside a session`() {
+        // No session at all: check() returns null, so the original code path runs.
+        assertEquals(2.5, calculator.applyRate(50.0, 0.05))
+    }
+
+    @Test
+    fun `fractional double result survives instrumentation in baseline`() {
+        val result = MutFlow.underTest(run = 0, selection = Selection.MostLikelyStable, shuffle = Shuffle.PerChange) {
+            calculator.applyRate(50.0, 0.05)
+        }
+        assertEquals(2.5, result)
+    }
+}


### PR DESCRIPTION
fix: wrong hard coded type on ir when on compiler plugin could cause issues with double precision arithmetics