### PR TITLE
feat: track all killing tests per mutation for full per-test-per-mutation zombie detection

### DIFF
--- a/mutflow-runtime/src/main/kotlin/io/github/anschnapp/mutflow/MutFlowSession.kt
+++ b/mutflow-runtime/src/main/kotlin/io/github/anschnapp/mutflow/MutFlowSession.kt
@@ -187,8 +187,8 @@ class MutFlowSession internal constructor(
         return includeTargets.isNotEmpty() || excludeTargets.isNotEmpty()
     }
 
-    // Name of the first test that killed the current mutation
-    private var killedByTest: String? = null
+    // All tests that killed the current mutation (tracked for full per-test-per-mutation matrix)
+    private val killedByTests = mutableSetOf<String>()
 
     /**
      * Marks that a test failed during the baseline run.
@@ -200,14 +200,14 @@ class MutFlowSession internal constructor(
 
     /**
      * Marks that a test failed in the current run (mutation killed).
-     * Called by JUnit extension's exception handler.
+     * Called by JUnit extension's exception handler. Tracks ALL tests
+     * that killed this mutation for full per-test-per-mutation analysis.
      *
      * @param testName The name of the test that killed the mutation
      */
     fun markTestFailed(testName: String) {
-        if (!testFailedInCurrentRun && activeMutation != null) {
-            // Record first test that killed this mutation
-            killedByTest = testName
+        if (activeMutation != null) {
+            killedByTests.add(testName)
         }
         testFailedInCurrentRun = true
     }
@@ -235,11 +235,11 @@ class MutFlowSession internal constructor(
         if (timedOutInCurrentRun) {
             mutationResults[mutation] = MutationResult.TimedOut
         } else if (testFailedInCurrentRun) {
-            mutationResults[mutation] = MutationResult.Killed(killedByTest ?: "unknown")
+            mutationResults[mutation] = MutationResult.Killed(killedByTests.toSet())
         } else {
             mutationResults[mutation] = MutationResult.Survived
         }
-        killedByTest = null
+        killedByTests.clear()
     }
 
     /**
@@ -539,8 +539,10 @@ class MutFlowSession internal constructor(
                 when (result) {
                     is MutationResult.Killed -> {
                         println("║  ✓ ${mutationStr.padEnd(61)}║")
-                        val testLine = "      killed by: ${result.testName}"
-                        println("║${testLine.take(64).padEnd(64)}║")
+                        result.testNames.sorted().forEach { testName ->
+                            val testLine = "      killed by: $testName"
+                            println("║${testLine.take(64).padEnd(64)}║")
+                        }
                     }
                     is MutationResult.Survived -> {
                         survivedMutations.add(mutationStr)
@@ -597,7 +599,7 @@ data class SessionState(
  * Result of testing a single mutation.
  */
 sealed class MutationResult {
-    data class Killed(val testName: String) : MutationResult()
+    data class Killed(val testNames: Set<String>) : MutationResult()
     data object Survived : MutationResult()
     data object TimedOut : MutationResult()
 }

--- a/mutflow-runtime/src/test/kotlin/io/github/anschnapp/mutflow/MutFlowTest.kt
+++ b/mutflow-runtime/src/test/kotlin/io/github/anschnapp/mutflow/MutFlowTest.kt
@@ -452,6 +452,126 @@ class MutFlowTest {
 
         MutFlow.closeSession(sessionId)
     }
+    @Test
+    fun `markTestFailed records all killing tests not just first`() {
+        val sessionId = MutFlow.createSession(
+            selection = Selection.MostLikelyStable,
+            shuffle = Shuffle.PerChange,
+            maxRuns = 10
+        )
+
+        runBaselineWithSession(sessionId) {
+            simulateMutationPoint("point-0", 2)
+        }
+
+        // Run mutation 1
+        val mutation = runMutationWithSession(sessionId, 1)
+        assertNotNull(mutation)
+
+        // Simulate 3 tests failing during the mutation run
+        val session = MutFlow.getSession(sessionId)!!
+        MutFlow.startRun(sessionId, 1, mutation)
+        MutFlow.underTest {
+            session.markTestFailed("testAlpha()")
+            session.markTestFailed("testBeta()")
+            session.markTestFailed("testGamma()")
+        }
+        session.recordMutationResult()
+
+        val summary = session.getSummary()
+        val result = summary.results[mutation]
+        assertNotNull(result, "Mutation should have a result")
+        assertIs<MutationResult.Killed>(result)
+        assertEquals(setOf("testAlpha()", "testBeta()", "testGamma()"), result.testNames,
+            "All killing tests should be recorded, not just the first")
+
+        MutFlow.closeSession(sessionId)
+    }
+
+    @Test
+    fun `markTestFailed with no killing tests stores Survived`() {
+        val sessionId = MutFlow.createSession(
+            selection = Selection.MostLikelyStable,
+            shuffle = Shuffle.PerChange,
+            maxRuns = 10
+        )
+
+        runBaselineWithSession(sessionId) {
+            simulateMutationPoint("point-0", 2)
+        }
+
+        val mutation = runMutationWithSession(sessionId, 1)
+        assertNotNull(mutation)
+
+        // No tests fail — mutation survives
+        MutFlow.closeSession(sessionId)
+    }
+
+    @Test
+    fun `markTestFailed ignores tests when no active mutation`() {
+        val sessionId = MutFlow.createSession(
+            selection = Selection.MostLikelyStable,
+            shuffle = Shuffle.PerChange,
+            maxRuns = 10
+        )
+
+        runBaselineWithSession(sessionId) {
+            simulateMutationPoint("point-0", 2)
+        }
+
+        val session = MutFlow.getSession(sessionId)!!
+        // markTestFailed without an active mutation should not store anything
+        session.markTestFailed("shouldNotBeRecorded()")
+        session.recordMutationResult()
+
+        // No mutation result should be recorded (no active mutation)
+        val summary = session.getSummary()
+        assertTrue(summary.results.isEmpty(), "No mutation results without active mutation")
+
+        MutFlow.closeSession(sessionId)
+    }
+
+    @Test
+    fun `printSummary outputs all killing tests`() {
+        val sessionId = MutFlow.createSession(
+            selection = Selection.MostLikelyStable,
+            shuffle = Shuffle.PerChange,
+            maxRuns = 10
+        )
+
+        runBaselineWithSession(sessionId) {
+            simulateMutationPoint("point-0", 2)
+        }
+
+        val mutation = runMutationWithSession(sessionId, 1)
+        assertNotNull(mutation)
+
+        val session = MutFlow.getSession(sessionId)!!
+        MutFlow.startRun(sessionId, 1, mutation)
+        MutFlow.underTest {
+            session.markTestFailed("testAlpha()")
+            session.markTestFailed("testBeta()")
+        }
+        session.recordMutationResult()
+
+        // Capture stdout
+        val originalOut = System.out
+        val captured = java.io.ByteArrayOutputStream()
+        System.setOut(java.io.PrintStream(captured))
+        try {
+            session.printSummary()
+        } finally {
+            System.setOut(originalOut)
+        }
+
+        val output = captured.toString()
+        assertTrue(output.contains("killed by: testAlpha()"),
+            "Summary should contain all killing tests: $output")
+        assertTrue(output.contains("killed by: testBeta()"),
+            "Summary should contain second killer: $output")
+
+        MutFlow.closeSession(sessionId)
+    }
 
     @Test
     fun `exhaustion works correctly with target filter`() {


### PR DESCRIPTION
mutflow's MutFlowSession previously only tracked the FIRST test that killed each mutation. This PR implements full per-test-per-mutation tracking by recording ALL tests that catch each mutation in MutationResult.Killed(testNames: Set<String>).

Changes:
- MutationResult.Killed: testName: String → testNames: Set<String>
- markTestFailed: removed !testFailedInCurrentRun guard, collects all killers
- recordMutationResult: stores immutable copy (.toSet()) to survive clear()
- printSummary: prints all 'killed by:' lines per mutation

Enables precise zombie detection in the OMP harness (test-auditor agent builds testKillerMatrix from all killers, not just first).

Related: PR #16 (ExceptionTypeSwapOperator - separate feature)