### PR TITLE
Fix compiler crash on range for loops in mutation targets

### DIFF
--- a/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutflowIrTransformer.kt
+++ b/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutflowIrTransformer.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.ir.expressions.IrBlockBody
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.types.isBoolean
 import org.jetbrains.kotlin.ir.expressions.impl.IrBlockImpl
+import org.jetbrains.kotlin.ir.declarations.IrVariable
 import org.jetbrains.kotlin.ir.expressions.impl.IrBranchImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrElseBranchImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrReturnImpl
@@ -396,6 +397,18 @@ class MutflowIrTransformer(
         val builder = DeclarationIrBuilder(pluginContext, fn.symbol)
         val checkCall = builder.irCall(checkTimeoutFn).also { call ->
             call.arguments[0] = builder.irGetObject(registryClass)
+        }
+
+        // A `for` loop is already lowered to a while loop whose body block must start with the
+        // loop-variable declarations (`val x = iterator.next()`): ForLoopsLowering pattern-matches
+        // them and fails with "No 'next' statement in for-loop" if anything precedes them.
+        // Insert the check after those declarations instead of wrapping the body.
+        val bodyBlock = body as? IrContainerExpression
+        if (loop.origin == IrStatementOrigin.FOR_LOOP_INNER_WHILE && bodyBlock != null) {
+            val insertAt = bodyBlock.statements.indexOfFirst { it !is IrVariable }
+                .let { if (it < 0) bodyBlock.statements.size else it }
+            bodyBlock.statements.add(insertAt, checkCall)
+            return
         }
 
         loop.body = IrBlockImpl(

--- a/mutflow-test-sample/src/main/kotlin/sample/RangeLoopTarget.kt
+++ b/mutflow-test-sample/src/main/kotlin/sample/RangeLoopTarget.kt
@@ -1,0 +1,23 @@
+package sample
+
+import io.github.anschnapp.mutflow.MutationTarget
+
+/**
+ * Target class with a range `for` loop.
+ *
+ * Kotlin lowers `for (i in 0 until n)` into a while loop whose body block must start with the
+ * loop-variable declaration; ForLoopsLowering pattern-matches that shape. Injecting the loop
+ * timeout check by wrapping the body used to break it and crash the compiler with
+ * "No 'next' statement in for-loop", so this class simply has to compile and still be mutated.
+ */
+@MutationTarget
+class RangeLoopTarget {
+
+    fun sumBelow(n: Int): Int {
+        var sum = 0
+        for (i in 0 until n) {
+            sum = sum + i
+        }
+        return sum
+    }
+}

--- a/mutflow-test-sample/src/test/kotlin/sample/RangeLoopTargetTest.kt
+++ b/mutflow-test-sample/src/test/kotlin/sample/RangeLoopTargetTest.kt
@@ -1,0 +1,36 @@
+package sample
+
+import io.github.anschnapp.mutflow.MutFlow
+import io.github.anschnapp.mutflow.MutationRegistry
+import io.github.anschnapp.mutflow.Selection
+import io.github.anschnapp.mutflow.Shuffle
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression test: a target class containing a range `for` loop must compile and its loop body
+ * must still be mutated. Before the fix the compiler crashed on this class.
+ */
+class RangeLoopTargetTest {
+
+    private val target = RangeLoopTarget()
+
+    @BeforeTest
+    fun setup() {
+        MutationRegistry.reset()
+        MutFlow.reset()
+    }
+
+    @Test
+    fun `range for loop compiles and is mutated`() {
+        val result = MutFlow.underTest(run = 0, selection = Selection.MostLikelyStable, shuffle = Shuffle.PerChange) {
+            target.sumBelow(4)
+        }
+        assertEquals(6, result)
+
+        val points = MutFlow.getRegistryState().discoveredPoints.filter { it.key.contains("RangeLoopTarget") }
+        assertTrue(points.isNotEmpty(), "Expected mutation points inside the loop body")
+    }
+}


### PR DESCRIPTION
A `@MutationTarget` class containing a range `for` loop, e.g.

```kotlin
for (i in 0 until n) { sum = sum + i }
```

fails to compile with:

```
Backend Internal error: Exception during IR lowering
Caused by: java.lang.IllegalStateException: No 'next' statement in for-loop
    at org.jetbrains.kotlin.backend.common.lower.loops.RangeLoopTransformer.gatherLoopVariableInfo
```

Cause: `injectTimeoutCheck` replaces the loop body with a new block `[checkTimeout(), body]`. Kotlin lowers a `for` loop to a while loop whose body block must start with the loop-variable declarations (`val i = iterator.next()`); `ForLoopsLowering` pattern-matches that shape and rejects anything in front of them.

Fix: for loops with origin `FOR_LOOP_INNER_WHILE`, insert the check after the leading `IrVariable` statements of the existing body block instead of wrapping it. `while` and `do-while` loops are unchanged.

Adds `RangeLoopTarget` to the sample module with a regression test: it fails to compile on `master` and passes here. Found while running mutflow against an Android app with a hand-written JUnit 4 runner; happy to adjust the test placement if you prefer it elsewhere.
