### PR TITLE
Fix ClassCastException on non-local returns in inline lambdas

### DIFF
--- a/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutflowIrTransformer.kt
+++ b/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutflowIrTransformer.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.*
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFile
+import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.IrBlockBody
 import org.jetbrains.kotlin.ir.expressions.*
@@ -701,8 +702,11 @@ class MutflowIrTransformer(
 
         val originalValue = original.value
 
-        // Use the function's return type for the when type
-        val blockType = containingFunction.returnType
+        // Type the when by the return's TARGET, not the enclosing function: a non-local return
+        // inside an inline lambda (`x?.let { return it }`) sits in a lambda whose return type is
+        // Nothing, and a Nothing-typed when would make the backend cast the value to Void.
+        val blockType = (original.returnTargetSymbol.owner as? IrFunction)?.returnType
+            ?: containingFunction.returnType
 
         // Helper to create a fresh check() call for each branch condition
         fun createCheckCall() = builder.irCall(checkFn).also { call ->

--- a/mutflow-test-sample/src/main/kotlin/sample/NonLocalReturnTarget.kt
+++ b/mutflow-test-sample/src/main/kotlin/sample/NonLocalReturnTarget.kt
@@ -1,0 +1,21 @@
+package sample
+
+import io.github.anschnapp.mutflow.MutationTarget
+
+/**
+ * Target class with non-local returns from inline lambdas (`x?.let { return it }`).
+ *
+ * The return sits in a lambda whose return type is Nothing while its target is the enclosing
+ * function. The nullable-return mutation used to type its generated `when` by the lambda, which
+ * made the backend cast the returned value to Void and throw ClassCastException at runtime,
+ * even with no mutation active.
+ */
+@MutationTarget
+class NonLocalReturnTarget {
+
+    fun firstPresent(a: Int?, b: Int?): Int? {
+        a?.let { return it }
+        b?.let { return it }
+        return null
+    }
+}

--- a/mutflow-test-sample/src/test/kotlin/sample/NonLocalReturnTargetTest.kt
+++ b/mutflow-test-sample/src/test/kotlin/sample/NonLocalReturnTargetTest.kt
@@ -1,0 +1,36 @@
+package sample
+
+import io.github.anschnapp.mutflow.MutFlow
+import io.github.anschnapp.mutflow.MutationRegistry
+import io.github.anschnapp.mutflow.Selection
+import io.github.anschnapp.mutflow.Shuffle
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression test: a non-local `return it` inside `?.let { }` must keep returning the value.
+ * Before the fix the baseline run threw ClassCastException (Integer cannot be cast to Void).
+ */
+class NonLocalReturnTargetTest {
+
+    private val target = NonLocalReturnTarget()
+
+    @BeforeTest
+    fun setup() {
+        MutationRegistry.reset()
+        MutFlow.reset()
+    }
+
+    @Test
+    fun `non-local return keeps its value and is mutated`() {
+        val result = MutFlow.underTest(run = 0, selection = Selection.MostLikelyStable, shuffle = Shuffle.PerChange) {
+            target.firstPresent(null, 7)
+        }
+        assertEquals(7, result)
+
+        val points = MutFlow.getRegistryState().discoveredPoints.filter { it.key.contains("NonLocalReturnTarget") }
+        assertTrue(points.isNotEmpty(), "Expected nullable-return mutation points")
+    }
+}


### PR DESCRIPTION
A `@MutationTarget` function using a non-local return from an inline lambda, e.g.

```kotlin
fun firstPresent(a: Int?, b: Int?): Int? {
    a?.let { return it }
    b?.let { return it }
    return null
}
```

compiles, but throws at runtime even with no mutation active:

```
java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.lang.Void
```

Cause: `transformReturnWithOperator` types the generated `when` with `containingFunction.returnType`, where `containingFunction` is the transformer's current function. For a non-local return that is the lambda, whose return type is `Nothing`, so the backend casts the returned value to `Void`. `NullableReturnOperator.matches` already resolves the return target correctly; the transformer did not.

Fix: type the `when` by `original.returnTargetSymbol.owner`'s return type, falling back to the enclosing function.

Adds `NonLocalReturnTarget` to the sample module with a regression test: on `master` the baseline call throws, here it returns the value and the nullable-return mutation points are discovered. Found while running mutflow against an Android app with a hand-written JUnit 4 runner.
