### PR TITLE
Skip boolean inversion when the call result is discarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [Unreleased]
+### Changed
+- Boolean inversion no longer mutates calls whose result is discarded (`list.add(x)` as a statement). Inverting an unused value is an equivalent mutant that no test can kill; in a run over 652 mutants these accounted for every "ignored" verdict. The inner expressions of such a call are still mutated (`rows.add(x > 0)` keeps its `>` mutations). (#21)
+
 ## [1.2.1] - 2026-09-08
 ### Fixed
 - Compiler crash on range `for` loops inside mutation targets. Kotlin lowers `for (i in 0 until n)` into a while loop whose body block has to start with the loop-variable declarations; `ForLoopsLowering` pattern-matches that shape and rejected the injected timeout check in front of them, failing the build with `Backend Internal error: ... No 'next' statement in for-loop`. For loops with `FOR_LOOP_INNER_WHILE` origin the check is now inserted after those declarations instead of wrapping the body. `while` and `do-while` loops are unchanged. (#19)

--- a/README.md
+++ b/README.md
@@ -788,6 +788,8 @@ fun inheritedSelection(invertSelection: Boolean, parentSelected: Boolean): Boole
 | `invertSelection → !invertSelection` | `if (!invertSelection)` | Test with `invertSelection=true` should invert |
 | `parentSelected → !parentSelected` | `!(!parentSelected)` / `!parentSelected` | Test should verify both branches |
 
+**Discarded results are not inverted:** a boolean call whose value is thrown away, such as `list.add(x)` or `flow.tryEmit(value)` on its own line, gets no inversion point. The call and its arguments still run exactly the same, so the mutant would be equivalent and no test could kill it. Only the outermost call of a statement counts as discarded; in `rows.add(x > 0)` the `>` is still mutated.
+
 **Negation removal is implicit:** There is no separate "remove `!`" mutation. Adding `!` to the inner expression of `!expr` produces `!(!expr)`, which evaluates to `expr` - achieving the same effect. This simplification covers all boolean types uniformly without special-casing negation.
 
 These mutations catch tests that don't verify the polarity of boolean results. If your test calls a function but doesn't assert the actual boolean value, the inversion mutation will survive.

--- a/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/BooleanInversionOperator.kt
+++ b/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/BooleanInversionOperator.kt
@@ -18,6 +18,8 @@ import org.jetbrains.kotlin.ir.util.deepCopyWithSymbols
  * Excludes:
  * - `not()` calls (would create redundant double-negation mutation points)
  * - Calls with EXCLEQ origin (handled by EqualitySwapOperator)
+ * - Calls whose result is discarded (`list.add(x)` as a statement): inverting
+ *   an unused value changes nothing observable, so the mutant would be equivalent
  */
 @OptIn(UnsafeDuringIrConstructionAPI::class)
 class BooleanInversionOperator : MutationOperator {
@@ -35,6 +37,7 @@ class BooleanInversionOperator : MutationOperator {
     }
 
     override fun variants(call: IrCall, context: MutationContext): List<MutationOperator.Variant> {
+        if (!context.resultUsed) return emptyList()
         val name = call.symbol.owner.name.asString()
 
         return listOf(

--- a/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutationOperator.kt
+++ b/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutationOperator.kt
@@ -47,9 +47,15 @@ interface MutationOperator {
 
 /**
  * Context passed to mutation operators during variant generation.
+ *
+ * [resultUsed] is false when the call sits in statement position and its value is
+ * discarded (`list.add(x)` on its own line). A mutation that only changes the
+ * returned value of such a call is an equivalent mutant: the program behaves the
+ * same and no test can kill it.
  */
 data class MutationContext(
     val pluginContext: IrPluginContext,
     val builder: IrBuilderWithScope,
-    val containingFunction: IrSimpleFunction
+    val containingFunction: IrSimpleFunction,
+    val resultUsed: Boolean = true
 )

--- a/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutflowIrTransformer.kt
+++ b/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutflowIrTransformer.kt
@@ -174,7 +174,18 @@ class MutflowIrTransformer(
         } else {
             statement
         }
-        if (expression is IrCall) discardedCalls.add(expression)
+        // The discarded value can come from a level deeper: a branch result of an `if` or
+        // `when`, a `try`/`catch` result, the value of a block such as a safe call.
+        when (expression) {
+            is IrCall -> discardedCalls.add(expression)
+            is IrWhen -> expression.branches.forEach { recordDiscardedCall(it.result) }
+            is IrTry -> {
+                recordDiscardedCall(expression.tryResult)
+                expression.catches.forEach { recordDiscardedCall(it.result) }
+            }
+            is IrContainerExpression -> expression.statements.lastOrNull()?.let { recordDiscardedCall(it) }
+            else -> {}
+        }
     }
 
     override fun visitFile(declaration: IrFile): IrFile {

--- a/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutflowIrTransformer.kt
+++ b/mutflow-compiler-plugin/src/main/kotlin/io/github/anschnapp/mutflow/compiler/MutflowIrTransformer.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.IrBlockBody
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.types.isBoolean
+import org.jetbrains.kotlin.ir.types.isUnit
 import org.jetbrains.kotlin.ir.expressions.impl.IrBlockImpl
 import org.jetbrains.kotlin.ir.declarations.IrVariable
 import org.jetbrains.kotlin.ir.expressions.impl.IrBranchImpl
@@ -143,6 +144,38 @@ class MutflowIrTransformer(
 
     // Compiled target patterns from Gradle config (glob-style → regex)
     private val compiledTargetPatterns: List<Regex> = compileTargetPatterns(targetPatterns)
+
+    /**
+     * Calls that sit in statement position with their value discarded. Recorded while
+     * entering a block, before its statements are transformed, so the identity of the
+     * original call still matches when [visitCall] reaches it. Only the outermost call
+     * of a statement is discarded: in `rows.add(x > 0)` the `>` result is used by `add`.
+     */
+    private val discardedCalls: MutableSet<IrCall> =
+        java.util.Collections.newSetFromMap(java.util.IdentityHashMap())
+
+    override fun visitBlockBody(body: IrBlockBody): IrBody {
+        body.statements.forEach { recordDiscardedCall(it) }
+        return super.visitBlockBody(body)
+    }
+
+    override fun visitContainerExpression(expression: IrContainerExpression): IrExpression {
+        // The last statement is the block's value unless the block itself is Unit.
+        val statements = expression.statements
+        statements.forEachIndexed { index, statement ->
+            if (index < statements.lastIndex || expression.type.isUnit()) recordDiscardedCall(statement)
+        }
+        return super.visitContainerExpression(expression)
+    }
+
+    private fun recordDiscardedCall(statement: IrStatement) {
+        val expression = if (statement is IrTypeOperatorCall && statement.operator == IrTypeOperator.IMPLICIT_COERCION_TO_UNIT) {
+            statement.argument
+        } else {
+            statement
+        }
+        if (expression is IrCall) discardedCalls.add(expression)
+    }
 
     override fun visitFile(declaration: IrFile): IrFile {
         debug("visitFile: ${declaration.fileEntry.name}")
@@ -487,7 +520,7 @@ class MutflowIrTransformer(
         }
 
         val builder = DeclarationIrBuilder(pluginContext, containingFunction.symbol)
-        val context = MutationContext(pluginContext, builder, containingFunction)
+        val context = MutationContext(pluginContext, builder, containingFunction, resultUsed = original !in discardedCalls)
 
         val variants = operator.variants(original, context)
         if (variants.isEmpty()) {

--- a/mutflow-test-sample/src/main/kotlin/sample/DiscardedResultTarget.kt
+++ b/mutflow-test-sample/src/main/kotlin/sample/DiscardedResultTarget.kt
@@ -28,4 +28,31 @@ class DiscardedResultTarget {
     fun addAllDiscarded(xs: List<Int>) {
         xs.forEach { items.add(it) }
     }
+
+    /** `if` used as a statement: the call is a branch result, not a statement itself. */
+    fun addInIf(c: Boolean) {
+        if (c) items.add(1)
+    }
+
+    /** Subject `when` used as a statement: its branches sit inside a block holding the subject. */
+    fun addInWhen(c: Int) {
+        when (c) {
+            1 -> items.add(1)
+            else -> items.add(2)
+        }
+    }
+
+    /** Safe call as a statement: the call is the value of the generated SAFE_CALL block. */
+    fun addSafeCall(other: MutableList<Int>?) {
+        other?.add(1)
+    }
+
+    /** `try` used as a statement: both the try result and the catch result are discarded. */
+    fun addInTry(index: Int) {
+        try {
+            items.add(items[index])
+        } catch (e: IndexOutOfBoundsException) {
+            items.add(0)
+        }
+    }
 }

--- a/mutflow-test-sample/src/main/kotlin/sample/DiscardedResultTarget.kt
+++ b/mutflow-test-sample/src/main/kotlin/sample/DiscardedResultTarget.kt
@@ -1,0 +1,31 @@
+package sample
+
+import io.github.anschnapp.mutflow.MutationTarget
+
+/**
+ * Boolean calls in statement position with their result discarded. Inverting such a result
+ * changes nothing observable, so no inversion mutation point may be generated for them.
+ */
+@MutationTarget
+class DiscardedResultTarget {
+    val items = mutableListOf<Int>()
+    val flags = mutableListOf<Boolean>()
+
+    /** `add` result discarded: no mutation point at all. */
+    fun addDiscarded(x: Int) {
+        items.add(x)
+    }
+
+    /** `add` result returned: the inversion point must stay. */
+    fun addUsed(x: Int): Boolean = items.add(x)
+
+    /** Outer `add` discarded, but the `>` inside its argument is still mutated. */
+    fun addComparison(x: Int) {
+        flags.add(x > 0)
+    }
+
+    /** Discarded inside a lambda body, where the compiler coerces the value to Unit. */
+    fun addAllDiscarded(xs: List<Int>) {
+        xs.forEach { items.add(it) }
+    }
+}

--- a/mutflow-test-sample/src/test/kotlin/sample/DiscardedResultTargetTest.kt
+++ b/mutflow-test-sample/src/test/kotlin/sample/DiscardedResultTargetTest.kt
@@ -1,0 +1,69 @@
+package sample
+
+import io.github.anschnapp.mutflow.MutFlow
+import io.github.anschnapp.mutflow.Mutation
+import io.github.anschnapp.mutflow.MutationRegistry
+import io.github.anschnapp.mutflow.Selection
+import io.github.anschnapp.mutflow.Shuffle
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Boolean inversion must skip calls whose result is discarded, and only those.
+ * Mutations are identified by their display names, e.g. `(DiscardedResultTarget.kt:16) add() → !add()`.
+ */
+class DiscardedResultTargetTest {
+
+    private val target = DiscardedResultTarget()
+
+    @BeforeTest
+    fun setup() {
+        MutationRegistry.reset()
+        MutFlow.reset()
+    }
+
+    /** Runs [block] as a baseline and returns the display names of every discovered mutation. */
+    private fun discoveredMutations(block: () -> Unit): List<String> {
+        val sessionId = MutFlow.createSession(Selection.MostLikelyStable, Shuffle.PerChange, maxRuns = Int.MAX_VALUE)
+        val session = MutFlow.getSession(sessionId)!!
+        try {
+            MutFlow.startRun(sessionId, 0, null)
+            session.underTest(block)
+            MutFlow.endRun(sessionId)
+            return session.getState().discoveredPoints
+                .filterKeys { it.contains("DiscardedResultTarget") }
+                .flatMap { (pointId, variants) -> (0 until variants).map { session.getDisplayName(Mutation(pointId, it)) } }
+        } finally {
+            MutFlow.closeSession(sessionId)
+        }
+    }
+
+    private fun List<String>.inversions() = filter { it.contains("add() → !add()") }
+
+    @Test
+    fun `discarded add is not inverted`() {
+        val mutations = discoveredMutations { target.addDiscarded(1) }
+        assertEquals(emptyList(), mutations.inversions(), "A discarded boolean result must not get an inversion point")
+    }
+
+    @Test
+    fun `used add keeps its inversion`() {
+        val mutations = discoveredMutations { target.addUsed(1) }
+        assertEquals(1, mutations.inversions().size, "Expected the inversion point, got $mutations")
+    }
+
+    @Test
+    fun `comparison inside a discarded add is still mutated`() {
+        val mutations = discoveredMutations { target.addComparison(1) }
+        assertTrue(mutations.any { it.contains("> → ") }, "The > inside the argument must still be mutated, got $mutations")
+        assertEquals(emptyList(), mutations.inversions(), "No inversion point for the discarded add itself")
+    }
+
+    @Test
+    fun `discarded add inside a lambda is not inverted`() {
+        val mutations = discoveredMutations { target.addAllDiscarded(listOf(1, 2)) }
+        assertEquals(emptyList(), mutations.inversions(), "Unit-coerced statement in a lambda body is discarded too")
+    }
+}

--- a/mutflow-test-sample/src/test/kotlin/sample/DiscardedResultTargetTest.kt
+++ b/mutflow-test-sample/src/test/kotlin/sample/DiscardedResultTargetTest.kt
@@ -66,4 +66,34 @@ class DiscardedResultTargetTest {
         val mutations = discoveredMutations { target.addAllDiscarded(listOf(1, 2)) }
         assertEquals(emptyList(), mutations.inversions(), "Unit-coerced statement in a lambda body is discarded too")
     }
+
+    @Test
+    fun `discarded add in an if branch is not inverted`() {
+        val mutations = discoveredMutations { target.addInIf(true) }
+        assertEquals(emptyList(), mutations.inversions(), "A branch result of a statement if is discarded, got $mutations")
+    }
+
+    @Test
+    fun `discarded add in a when branch is not inverted`() {
+        val mutations = discoveredMutations {
+            target.addInWhen(1)
+            target.addInWhen(2)
+        }
+        assertEquals(emptyList(), mutations.inversions(), "Both when branch results are discarded, got $mutations")
+    }
+
+    @Test
+    fun `discarded add behind a safe call is not inverted`() {
+        val mutations = discoveredMutations { target.addSafeCall(mutableListOf()) }
+        assertEquals(emptyList(), mutations.inversions(), "The value of the safe call block is discarded, got $mutations")
+    }
+
+    @Test
+    fun `discarded add in try and catch is not inverted`() {
+        val mutations = discoveredMutations {
+            target.addInTry(0) // list still empty: the catch branch runs
+            target.addInTry(0) // list now populated: the try branch runs
+        }
+        assertEquals(emptyList(), mutations.inversions(), "try and catch results are discarded, got $mutations")
+    }
 }


### PR DESCRIPTION
Implements the approach from #21.

**What changes**

- `MutflowIrTransformer` records, on entering a block body or container expression, the calls that sit in statement position with their value discarded. The implicit `IMPLICIT_COERCION_TO_UNIT` wrapper is unwrapped. For a container expression the last statement counts as discarded only when the block's type is Unit, since otherwise it is the block's value. The set is identity-based and filled before the children are transformed, so it still matches the original call when `visitCall` reaches it.
- `MutationContext` gains `resultUsed` (default `true`). No operator signature changes.
- `BooleanInversionOperator.variants` returns no variant when `resultUsed` is false; the transformer then falls through to the remaining operators as it already does for empty variant lists, so no point id is consumed.
- Only the outermost call of a statement is discarded: in `rows.add(x > 0)` the `>` keeps its mutations.

**Regression coverage** (`mutflow-test-sample`): `DiscardedResultTarget` with four shapes, discarded `add` as a statement, `add` as a returned value, `add(x > 0)`, and a discarded `add` inside a `forEach` lambda. The test identifies mutations by display name, so it is not confused by the Unit-body removal point that also has a single variant.

README (boolean inversion section) and CHANGELOG (Unreleased) updated.

Closes #21
